### PR TITLE
sistEndret er allerede en Long, trenger ikke caste via String.

### DIFF
--- a/src/main/kotlin/no/nav/cv/event/cv/CvConsumer.kt
+++ b/src/main/kotlin/no/nav/cv/event/cv/CvConsumer.kt
@@ -98,6 +98,6 @@ private fun GenericRecord.cv() = get("cv") as GenericRecord?
 
 private fun GenericRecord.jobbprofil() = get("jobbprofil") as GenericRecord?
 
-private fun GenericRecord.sistEndret(): Long? = (get("sist_endret") as String?)?.toLong()
+private fun GenericRecord.sistEndret(): Long? = get("sist_endret") as Long?
 
 private fun GenericRecord.aktoerId() = get("aktoer_id") as String?


### PR DESCRIPTION
java.lang.ClassCastException: class java.lang.Long cannot be cast to class java.lang.String (java.lang.Long and java.lang.String are in module java.base of loader 'bootstrap')
at no.nav.cv.event.cv.CvConsumerKt.sistEndret(CvConsumer.kt:101)