### PR TITLE
We have to keep the first reference `meterRegistry.gauge()` returns a…

### DIFF
--- a/src/main/kotlin/no/nav/cv/infrastructure/metrics/GenerateMetrics.kt
+++ b/src/main/kotlin/no/nav/cv/infrastructure/metrics/GenerateMetrics.kt
@@ -3,23 +3,34 @@ package no.nav.cv.infrastructure.metrics
 import io.micrometer.core.instrument.MeterRegistry
 import no.nav.cv.notifikasjon.StatusRepository
 import org.springframework.scheduling.annotation.Scheduled
+import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Singleton
 
 @Singleton
 class GenerateMetrics(
-        private val meterRegistry: MeterRegistry,
-        private val statusRepository: StatusRepository
+    private val meterRegistry: MeterRegistry,
+    private val statusRepository: StatusRepository
 ) {
+
+    val gauges = mutableMapOf<String, AtomicLong>()
+
+    private fun addOrUpdateGauge(name: String, value: Long) {
+        gauges[name]?.set(value)
+            ?: addGauge(name, value)
+    }
+
+    private fun addGauge(name: String, value: Long) {
+        gauges[name] = meterRegistry.gauge(name, AtomicLong(value))
+    }
 
     @Scheduled(fixedDelay = 5*60*1000) // Every 5 minutes
     fun generateMetrics() {
 
         val antallVarslet = statusRepository.antallAvStatus("varslet")
-        meterRegistry.gauge("cv.brukernotifikasjon.status.varslet", antallVarslet)
+        addOrUpdateGauge("cv.brukernotifikasjon.status.varslet", antallVarslet)
 
         val antallFerdig = statusRepository.antallAvStatus("done")
-        meterRegistry.gauge("cv.brukernotifikasjon.status.ferdig", antallFerdig)
-
+        addOrUpdateGauge("cv.brukernotifikasjon.status.ferdig", antallFerdig)
 
     }
 }


### PR DESCRIPTION
…s that is the one we need to update. Else it seems arbitrary which value gets reported to Prometheus.

