### PR TITLE
Only process messages that have been initiated by the user

### DIFF
--- a/src/main/kotlin/no/nav/cv/event/cv/CvEndretProcessor.kt
+++ b/src/main/kotlin/no/nav/cv/event/cv/CvEndretProcessor.kt
@@ -25,8 +25,8 @@ class CvEndretProcessor (
     ) {
         val cv = CvDto(record.value())
 
-        if(!cv.slettetCv()) {
-            log.info("Kafka CV msg for ${cv.aktorId()} is NOT a deletion msg")
+        if(!cv.slettetCv() && cv.endretAvBruker()) {
+            log.info("Kafka CV msg for ${cv.aktorId()} is NOT a deletion msg and was initiated by user")
             hendelseService.endretCV(cv.aktorId(), cv.sistEndret())
         } else {
             log.info("Kafka CV msg for ${cv.aktorId()} is a deletion msg, so skipping it")
@@ -49,6 +49,8 @@ private class CvDto(val record: GenericRecord) {
             ZonedDateTime.ofInstant(Instant.ofEpochMilli(sistEndretMillis()), TimeZone.getDefault().toZoneId())
 
     fun slettetCv() = record.get("meldingstype")?.toString()?.equals("SLETT") == true
+
+    fun endretAvBruker() = record.get("endret_av")?.toString()?.equals("PERSONBRUKER") == true
 
     private fun sistEndretMillis() = record.sistEndret()
             ?: throw Exception("Record mangler sistEndret")

--- a/src/main/kotlin/no/nav/cv/event/cv/CvEndretProcessor.kt
+++ b/src/main/kotlin/no/nav/cv/event/cv/CvEndretProcessor.kt
@@ -50,7 +50,11 @@ private class CvDto(val record: GenericRecord) {
 
     fun slettetCv() = record.get("meldingstype")?.toString()?.equals("SLETT") == true
 
-    fun endretAvBruker() = record.get("endret_av")?.toString()?.equals("PERSONBRUKER") == true
+    /**
+     * This function will return true if the 'endret_av' value doesn't exist in the record and if the
+     * value exists and equals 'PERSONBRUKER' in order to keep changes backwards compatible.
+    */
+    fun endretAvBruker() = record.get("endret_av")?.toString()?.equals("PERSONBRUKER") != false
 
     private fun sistEndretMillis() = record.sistEndret()
             ?: throw Exception("Record mangler sistEndret")


### PR DESCRIPTION
With the introduction of new the new updatedBy (endret_av) field, we can discern whether it was the user who initiated the CV update or not in order to avoid setting the state to finished prematurely due to delays in our kafka producer.