### PR TITLE
Metrics for conversion rate per week as a REST endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ object Version {
 
 dependencies {
     implementation("ch.qos.logback:logback-classic:1.2.3")
-    implementation("com.h2database:h2")
+    implementation("com.h2database:h2:1.4.200")
     implementation("com.github.navikt:brukernotifikasjon-schemas:${Version.brukernotifikasjoner}")
     implementation("io.confluent:kafka-streams-avro-serde:${Version.confluent}")
     implementation("io.micrometer:micrometer-registry-prometheus")

--- a/src/main/kotlin/no/nav/cv/infrastructure/metrics/ConversionRateController.kt
+++ b/src/main/kotlin/no/nav/cv/infrastructure/metrics/ConversionRateController.kt
@@ -1,0 +1,29 @@
+package no.nav.cv.infrastructure.metrics
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import no.nav.cv.notifikasjon.StatusRepository
+import no.nav.security.token.support.core.api.Unprotected
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/internal/metrics")
+@Unprotected
+class ConversionRateController(
+    private val statusRepository: StatusRepository
+) {
+
+    private val log = LoggerFactory.getLogger(ConversionRateController::class.java)
+
+    @OptIn(ExperimentalSerializationApi::class)
+    @GetMapping("/conversionRate", produces = ["application/json"])
+    fun getConversionRate() = statusRepository
+        .conversionRateWeekly()
+        .also { log.info("Conversion rate endpoint queried. Returning ${it.size} rows.") }
+        .let { Json.encodeToString(it) }
+
+}

--- a/src/main/kotlin/no/nav/cv/infrastructure/metrics/GenerateMetrics.kt
+++ b/src/main/kotlin/no/nav/cv/infrastructure/metrics/GenerateMetrics.kt
@@ -30,13 +30,6 @@ class GenerateMetrics(
 
         val antallFerdigIkkeUnderOppfolging = statusRepository.antallFerdig(ikkeUnderOppfølgingStatus)
         addOrUpdateGauge("cv.brukernotifikasjon.ferdig.$ikkeUnderOppfølgingStatus", antallFerdigIkkeUnderOppfolging)
-
-        statusRepository.conversionRateWeekly()
-            .also { log.info("Conversion rate per week\n" +
-                it.joinToString { (week, status, count) ->
-                    "$week $status $count\n"
-                }
-            ) }
     }
 
     private fun update(status: String) : Long {

--- a/src/test/kotlin/no/nav/cv/infrastructure/metrics/GenerateMetricsTest.kt
+++ b/src/test/kotlin/no/nav/cv/infrastructure/metrics/GenerateMetricsTest.kt
@@ -1,17 +1,21 @@
 package no.nav.cv.infrastructure.metrics
 
 import io.micrometer.core.instrument.MeterRegistry
-import no.nav.cv.notifikasjon.Status
-import no.nav.cv.notifikasjon.StatusRepository
+import no.nav.cv.notifikasjon.*
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
 import java.time.ZonedDateTime
 
-@Disabled
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @SpringBootTest
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
 internal class GenerateMetricsTest {
 
 
@@ -19,10 +23,10 @@ internal class GenerateMetricsTest {
     private lateinit var statusRepository: StatusRepository
 
     @Autowired
-    private lateinit var  generateMetrics: GenerateMetrics
+    private lateinit var generateMetrics: GenerateMetrics
 
     @Autowired
-    private lateinit var  meterRegistry: MeterRegistry
+    private lateinit var meterRegistry: MeterRegistry
 
     @Test
     fun `create some varslet status - ensure each is counted`() {
@@ -31,9 +35,10 @@ internal class GenerateMetricsTest {
 
         val skalVarslesStatus = Status.nySession(aidA).skalVarlsesManglerFnr(ZonedDateTime.now())
         val varsletStatusA = Status.varslet(
-                forrigeStatus = skalVarslesStatus,
-                foedselsnummer = fnrA,
-                statusTidspunkt = ZonedDateTime.now())
+            forrigeStatus = skalVarslesStatus,
+            foedselsnummer = fnrA,
+            statusTidspunkt = ZonedDateTime.now()
+        )
 
         statusRepository.lagreNyStatus(varsletStatusA)
 
@@ -48,5 +53,42 @@ internal class GenerateMetricsTest {
         assertEquals(1.0, antallVarsletA)
     }
 
+    @Test
+    fun `conversion rate`() {
+
+        val ids = listOf(
+            "123" to "321",
+            "456" to "654",
+            "789" to "987",
+            "000" to "999",
+            "111" to "888",
+            "222" to "777"
+        )
+
+        val statuses = ids.map { (aid, fnr) ->
+            Status
+                .nySession(aid)
+                .skalVarlsesManglerFnr(ZonedDateTime.now())
+                .varslet(foedselsnummer = fnr, tidspunkt = ZonedDateTime.now())
+        }
+            .onEach { status ->
+                statusRepository.lagreNyStatus(status)
+            }
+
+        statuses[1].endretCV(ZonedDateTime.now())
+            .let { statusRepository.lagreNyStatus(it) }
+
+        statuses[2].endretCV(ZonedDateTime.now())
+            .let { statusRepository.lagreNyStatus(it) }
+
+        statuses[3].ikkeUnderOppfølging(ZonedDateTime.now())
+            .let { statusRepository.lagreNyStatus(it) }
+
+        val res = statusRepository.conversionRateWeekly()
+
+        assertTrue(res.any { it.status == varsletStatus && it.count == 3L })
+        assertTrue(res.any { it.status == cvOppdatertStatus && it.count == 2L })
+        assertTrue(res.any { it.status == ikkeUnderOppfølgingStatus && it.count == 1L })
+    }
 
 }


### PR DESCRIPTION
Add a REST endpoint for fetching the current status of varsel sent per year and week. Using REST instead of going through Prometheus since that's easier for Luis.