### PR TITLE
Bytter ut H2 med Postgres (via Testcontainers)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
     runtimeOnly("org.springframework.boot:spring-boot-properties-migrator") // Mildertidig kun fo å fikse migrering av properties ved Spring oppgradering
     compileOnly("jakarta.platform:jakarta.jakartaee-api:10.0.0")
 
-    implementation("com.h2database:h2:2.1.214")
     implementation("com.github.navikt:brukernotifikasjon-schemas:${Version.brukernotifikasjoner}")
     implementation("io.confluent:kafka-streams-avro-serde:${Version.confluent}")
     implementation("io.micrometer:micrometer-registry-prometheus")
@@ -73,6 +72,11 @@ dependencies {
     testImplementation("org.testcontainers:kafka:1.17.4")
     testImplementation("org.mock-server:mockserver-netty:5.15.0")
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
+    testImplementation("org.testcontainers:testcontainers:1.19.6")
+    testImplementation("org.testcontainers:junit-jupiter:1.19.6")
+    testImplementation("org.testcontainers:postgresql:1.19.6")
+    testImplementation("org.fusesource.jansi:jansi:1.18")
 
 }
 

--- a/src/test/kotlin/no/nav/cv/SingletonPostgresTestInstance.kt
+++ b/src/test/kotlin/no/nav/cv/SingletonPostgresTestInstance.kt
@@ -1,0 +1,45 @@
+package no.nav.cv
+
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.testcontainers.containers.PostgreSQLContainer
+
+@SpringBootTest
+@ActiveProfiles("test")
+abstract class SingletonPostgresTestInstance {
+
+    companion object {
+        val postgresContainer: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:15-alpine").apply {
+            start()
+            System.setProperty("spring.datasource.url", jdbcUrl)
+            System.setProperty("spring.datasource.username", username)
+            System.setProperty("spring.datasource.password", password)
+        }
+    }
+
+    @Autowired
+    lateinit var flyway : Flyway
+
+    @BeforeEach
+    fun prepareSchema() {
+        ventTilDatabasenHarStartet()
+        flyway.migrate()
+    }
+
+    private fun ventTilDatabasenHarStartet() {
+        while (!postgresContainer.isRunning()) {
+            println("Test-container-en for Postgres er ikke klar enda, venter til den er klar før vi går videre")
+            Thread.sleep(500)
+        }
+    }
+
+    @AfterEach
+    fun clearTestdata() {
+        flyway.clean()
+    }
+
+}

--- a/src/test/kotlin/no/nav/cv/event/oppfolgingstatus/OppfolgingstatusDeserializationTestInstance.kt
+++ b/src/test/kotlin/no/nav/cv/event/oppfolgingstatus/OppfolgingstatusDeserializationTestInstance.kt
@@ -3,25 +3,23 @@ package no.nav.cv.event.oppfolgingstatus
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.nav.cv.notifikasjon.*
+import no.nav.cv.SingletonPostgresTestInstance
+import no.nav.cv.notifikasjon.Hendelser
+import no.nav.cv.notifikasjon.StatusRepository
+import no.nav.cv.notifikasjon.ikkeUnderOppfølgingStatus
+import no.nav.cv.notifikasjon.skalVarslesManglerFnrStatus
 import no.nav.cv.output.OutboxService
 import org.apache.kafka.clients.consumer.ConsumerRecord
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
-import org.springframework.context.annotation.ComponentScan
-import org.springframework.context.annotation.FilterType
-import org.springframework.stereotype.Repository
 import java.time.ZonedDateTime
 
-@DataJpaTest(includeFilters = [ComponentScan.Filter(type = FilterType.ANNOTATION, classes = [Repository::class])])
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class OppfolgingstatusDeserializationTest {
+class OppfolgingstatusDeserializationTestInstance : SingletonPostgresTestInstance() {
+
     @Autowired
     lateinit var statusRepository: StatusRepository
 

--- a/src/test/kotlin/no/nav/cv/infrastructure/metrics/GenerateMetricsTestInstance.kt
+++ b/src/test/kotlin/no/nav/cv/infrastructure/metrics/GenerateMetricsTestInstance.kt
@@ -1,22 +1,19 @@
 package no.nav.cv.infrastructure.metrics
 
 import io.micrometer.core.instrument.MeterRegistry
-import no.nav.cv.notifikasjon.*
+import no.nav.cv.SingletonPostgresTestInstance
+import no.nav.cv.notifikasjon.Status
+import no.nav.cv.notifikasjon.StatusRepository
+import no.nav.cv.notifikasjon.cvOppdatertStatus
+import no.nav.cv.notifikasjon.ikkeUnderOppfølgingStatus
+import no.nav.cv.notifikasjon.varsletStatus
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.annotation.DirtiesContext
 import java.time.ZonedDateTime
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-@SpringBootTest
-@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
-internal class GenerateMetricsTest {
-
+internal class GenerateMetricsTestInstance : SingletonPostgresTestInstance() {
 
     @Autowired
     private lateinit var statusRepository: StatusRepository

--- a/src/test/kotlin/no/nav/cv/notifikasjon/NotifikasjonAdminTestInstance.kt
+++ b/src/test/kotlin/no/nav/cv/notifikasjon/NotifikasjonAdminTestInstance.kt
@@ -1,18 +1,13 @@
 package no.nav.cv.notifikasjon
 
+import no.nav.cv.SingletonPostgresTestInstance
 import no.nav.cv.output.OutboxEntry
 import no.nav.cv.output.OutboxRepository
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestPropertySource
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
@@ -22,13 +17,9 @@ import java.util.*
 private val uuid = UUID.randomUUID().toString()
 private val fnr = "123dummy123"
 
-@SpringBootTest
-@ExtendWith(SpringExtension::class)
 @AutoConfigureMockMvc(addFilters = false)
 @TestPropertySource(properties = ["admin.enabled:enabled"])
-@ContextConfiguration
-@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
-class NotifikasjonAdminTest {
+class NotifikasjonAdminTestInstance : SingletonPostgresTestInstance() {
 
     @Autowired
     lateinit var outboxRepository: OutboxRepository
@@ -71,13 +62,9 @@ class NotifikasjonAdminTest {
 
 }
 
-@SpringBootTest
-@ExtendWith(SpringExtension::class)
 @AutoConfigureMockMvc(addFilters = false)
 @TestPropertySource(properties = ["admin.enabled:disabled"])
-@ContextConfiguration
-@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
-class NotifikasjonAdminDisabledTest {
+class NotifikasjonAdminDisabledTestInstance : SingletonPostgresTestInstance() {
 
     @Autowired
     private lateinit var mvc: MockMvc

--- a/src/test/kotlin/no/nav/cv/notifikasjon/OutboxTestInstance.kt
+++ b/src/test/kotlin/no/nav/cv/notifikasjon/OutboxTestInstance.kt
@@ -3,25 +3,16 @@ package no.nav.cv.notifikasjon
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.mockk.slot
+import no.nav.cv.SingletonPostgresTestInstance
 import no.nav.cv.output.OutboxService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.TestPropertySource
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.util.*
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-@SpringBootTest
-@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
-@ExtendWith(SpringExtension::class)
 @TestPropertySource(properties = ["schedulingEnabled=false"])
-internal class OutboxTest {
+internal class OutboxTestInstance : SingletonPostgresTestInstance() {
 
     @Autowired
     private lateinit var outboxService: OutboxService
@@ -65,6 +56,5 @@ internal class OutboxTest {
         assertEquals(uuid.toString(), uuidSlot.captured)
         assertEquals(fnr, fnrSlot.captured)
     }
-
 
 }

--- a/src/test/kotlin/no/nav/cv/notifikasjon/StatusEntityRepositoryTestInstance.kt
+++ b/src/test/kotlin/no/nav/cv/notifikasjon/StatusEntityRepositoryTestInstance.kt
@@ -2,26 +2,18 @@ package no.nav.cv.notifikasjon
 
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
+import no.nav.cv.SingletonPostgresTestInstance
 import no.nav.cv.personident.PersonOppslag
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
-import org.springframework.context.annotation.ComponentScan
-import org.springframework.context.annotation.FilterType
-import org.springframework.stereotype.Repository
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.time.ZonedDateTime
 
-@DataJpaTest(includeFilters = [ComponentScan.Filter(type = FilterType.ANNOTATION, classes = [Repository::class])])
-@ExtendWith(SpringExtension::class)
-class StatusEntityRepositoryTest {
+class StatusEntityRepositoryTestInstance : SingletonPostgresTestInstance() {
 
     val aktorId = "dummy"
     val aktorId2 = "dummy2"
-
 
     @MockkBean(PersonOppslag::class)
     private lateinit var personOppslag : PersonOppslag
@@ -82,6 +74,5 @@ class StatusEntityRepositoryTest {
 
         assertEquals(savedFirst.uuid, fetchedStatus.uuid)
     }
-
 
 }

--- a/src/test/kotlin/no/nav/cv/notifikasjon/StatusEntityRepositoryTestInstance.kt
+++ b/src/test/kotlin/no/nav/cv/notifikasjon/StatusEntityRepositoryTestInstance.kt
@@ -29,9 +29,9 @@ class StatusEntityRepositoryTestInstance : SingletonPostgresTestInstance() {
     @MockkBean(relaxed = true)
     lateinit var varselPublisherMock: VarselPublisher
 
-    private val now = ZonedDateTime.now()
-    private val yesterday = ZonedDateTime.now().minusDays(1)
-    private val twoDaysAgo = ZonedDateTime.now().minusDays(2)
+    private val now = ZonedDateTime.now().withNano(0) // Set nanoseconds to deal with rounding errors in CI
+    private val yesterday = now.minusDays(1)
+    private val twoDaysAgo = now.minusDays(2)
 
     @Test
     fun `save and fetch`() {

--- a/src/test/kotlin/no/nav/cv/notifikasjon/StatusTestNyInstance.kt
+++ b/src/test/kotlin/no/nav/cv/notifikasjon/StatusTestNyInstance.kt
@@ -4,26 +4,17 @@ package no.nav.cv.notifikasjon
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.mockk.verify
+import no.nav.cv.SingletonPostgresTestInstance
 import no.nav.cv.personident.PersonOppslag
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.annotation.DirtiesContext
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.time.ZonedDateTime
 import kotlin.random.Random
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-@SpringBootTest
-@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
-@ExtendWith(SpringExtension::class)
-internal class StatusTestNy {
+internal class StatusTestNyInstance : SingletonPostgresTestInstance() {
 
     private val rnd = Random(42)
     var aktoer = "will be replaced"

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,19 +1,3 @@
-#kafka:
-#  schema:
-#    registry:
-#      url: http://mock:8081/
 spring:
-  datasources:
-    default:
-      url: 'jdbc:h2:mem:pam-brukernotifikasjon;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE'
-      username: 'sa'
-      password: ''
-      driverClassName: 'org.h2.Driver'
   flyway:
-    datasources:
-      default:
-        locations: classpath:databasemigrations
-        initSql:
-          - ''
-        connection-init-sqls:
-          - 'SET ROLE "pam-brukernotifikasjon-admin"'
+    clean-disabled: false


### PR DESCRIPTION
Fyrer opp kun en Postgres instans som alle testene bruker, siden dette er en dyr operasjon. Databasen blir tømt og migrert mellom hver enkelt test.

Kommer ikke til å prodsette denne før https://github.com/navikt/pam-brukernotifikasjon/pull/41 er ferdig, og ute i prod.