### PR TITLE
Lager endepunkt som lukker alle åpne varsler. Stopper også consumerne

### DIFF
--- a/src/main/kotlin/no/nav/cv/infrastructure/health/ApplicationStatusController.kt
+++ b/src/main/kotlin/no/nav/cv/infrastructure/health/ApplicationStatusController.kt
@@ -21,12 +21,7 @@ class ApplicationStatusController(
 
     @GetMapping("/isAlive")
     fun isAlive(): ResponseEntity<String> {
-        return if(consumerStatusHandler.isUnhealthy()) {
-            log.error("isAlive check: Kafka consumers unhealthy")
-            ResponseEntity.internalServerError().build()
-        } else {
-            ResponseEntity.ok("OK")
-        }
+        return ResponseEntity.ok("OK")
     }
 
 }

--- a/src/main/kotlin/no/nav/cv/infrastructure/kafka/ConsumerStatusHandler.kt
+++ b/src/main/kotlin/no/nav/cv/infrastructure/kafka/ConsumerStatusHandler.kt
@@ -19,10 +19,11 @@ class ConsumerStatusHandler(
             .map { it.topic to AtomicInteger(0) }
             .toMap()
 
-    @EventListener(ApplicationReadyEvent::class)
-    fun startUp() = consumers.forEach { it.startPolling() }
+    // Fjernet listener for å forberede sletting av alle sendte varsler (og app)
+    //@EventListener(ApplicationReadyEvent::class)
+    //fun startUp() = consumers.forEach { it.startPolling() }
 
-    @Scheduled(fixedRate = 60000)
+    //@Scheduled(fixedRate = 60000)
     fun checkForStoppedConsumers() {
         consumers.forEach {
             if(it.isStopped()) {

--- a/src/main/kotlin/no/nav/cv/notifikasjon/AdminService.kt
+++ b/src/main/kotlin/no/nav/cv/notifikasjon/AdminService.kt
@@ -1,0 +1,30 @@
+package no.nav.cv.notifikasjon
+
+import no.nav.cv.output.OutboxService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class AdminService(
+    private val statusRepository: StatusRepository,
+    private val outboxService: OutboxService
+) {
+    companion object {
+        private val log = LoggerFactory.getLogger(NotifikasjonAdmin::class.java)
+    }
+
+    @Transactional
+    fun lukkAlleÅpneVarsler() {
+        val åpneVarlser = statusRepository.finnAlleMedÅpneVarsler()
+
+        log.info("Fant ${åpneVarlser.size} åpne varlser")
+
+        åpneVarlser.forEach {
+            statusRepository.settFerdig(it.aktoerId)
+            outboxService.schdeuleDone(it.uuid, it.aktoerId, it.fnr)
+        }
+
+        log.info("Markerte ${åpneVarlser.size} statuser med varslet som ferdig og skedulerte DONE-melding")
+    }
+}

--- a/src/main/kotlin/no/nav/cv/notifikasjon/NotifikasjonAdmin.kt
+++ b/src/main/kotlin/no/nav/cv/notifikasjon/NotifikasjonAdmin.kt
@@ -18,7 +18,8 @@ import java.util.*
 @RequestMapping("internal/kafka/manuell")
 class NotifikasjonAdmin(
         @Value("\${admin.enabled}") private val adminEnabled: Boolean,
-        private val outboxService: OutboxService
+        private val outboxService: OutboxService,
+        private val adminService: AdminService,
 ) {
 
     companion object {
@@ -58,4 +59,15 @@ class NotifikasjonAdmin(
         return "OK"
     }
 
+
+    @GetMapping("lukk_alle", produces = [ "text/plain" ])
+    fun done(): String {
+        log.warn("Call for NotifikasjonAdmin with adminEnabled: ${adminEnabled}")
+        if(!adminEnabled) throw ResponseStatusException(HttpStatus.UNAUTHORIZED)
+
+        log.info("NotifikasjonAdmin genererer done melding alle aktive")
+
+        adminService.lukkAlleÅpneVarsler()
+        return "OK"
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,7 +67,7 @@ kafka:
     schemaPassword: ${KAFKA_SCHEMA_REGISTRY_PASSWORD:none}
 
 admin:
-  enabled: ${ADMIN_ENABLED:false}
+  enabled: true # Siste som skal skje før applikasjonen blir stoppet for alltid er skjult bak denne toggelen.
 
 metrics.key.conversion_rate: ${METRIC_CONVERSIONRATE:noset}
 


### PR DESCRIPTION
Klargjøring til å ta livet av appen: 
  * admin-toggle hardkodet til true
  * admin-endepunkt for å lukke alle åpne varsler
  * alle consumere er skrudd av for å ikke sende nye varsler
  * health-service sier AOK uavhengig av consumere
